### PR TITLE
more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Options include:
   },
   socket (socket) {
     // called when an incoming socket is received
-  }
+  },
+  // Optionally overwrite the default set of bootstrap servers
+  bootstrap: [addresses]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const net = require('net')
 const Nanoresource = require('nanoresource')
 const discovery = require('@hyperswarm/discovery')
 
-module.exports = (opts, handlers) => new NetworkResource(opts, handlers)
+module.exports = (opts) => new NetworkResource(opts)
 
 class NetworkResource extends Nanoresource {
   constructor (opts) {
@@ -59,7 +59,6 @@ class NetworkResource extends Nanoresource {
 
     function onholepunch (err) {
       if (connected) return
-
       if (err) {
         if (!--closes) return cb(err)
         return

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class NetworkResource extends Nanoresource {
     this._onbind = opts.bind || noop
     this._onclose = opts.close || noop
     this._onsocket = opts.socket || noop
+    this._bootstrap = opts.bootstrap
 
     this.utp.on('connection', this._onincoming.bind(this, false))
     this.tcp.on('connection', this._onincoming.bind(this, true))
@@ -124,7 +125,10 @@ class NetworkResource extends Nanoresource {
     }
 
     function onlisten () {
-      self.discovery = discovery({ socket: self.utp })
+      self.discovery = discovery({
+        bootstrap: self._bootstrap,
+        socket: self.utp
+      })
       self._onbind()
       cb(null)
     }

--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ class NetworkResource extends Nanoresource {
         if (!--closes) return cb(new Error('Could not connect'))
         return
       }
-
       self.discovery.holepunch(peer, onholepunch)
     }
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "utp-native": "^2.1.3"
   },
   "devDependencies": {
+    "@hyperswarm/dht": "0.0.1",
     "events.once": "^2.0.2",
     "standard": "^12.0.1",
-    "tap": "^12.6.3"
+    "tap": "^12.6.6"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ const net = require('net')
 const dgram = require('dgram')
 const UTP = require('utp-native')
 const once = require('events.once')
-const { test } = require('tap')
+const { test, only } = require('tap')
 const guts = require('..')
 
 const promisifyApi = (o) => {
@@ -44,6 +44,7 @@ test('network bound – bind option', async ({ pass, plan }) => {
   await network.bind()
   await network.close()
 })
+
 test('network closed – close option', async ({ pass, plan }) => {
   plan(1)
   const network = promisifyApi(guts({
@@ -51,6 +52,24 @@ test('network closed – close option', async ({ pass, plan }) => {
   }))
   await network.bind()
   await network.close()
+})
+
+test('announce before bind will throw', async ({ throws }) => {
+  const network = guts()
+  const topic = randomBytes(32)
+  throws(() => network.announce(topic), Error('Bind before announcing'))
+})
+
+test('lookupOne before bind will throw', async ({ throws }) => {
+  const network = guts()
+  const topic = randomBytes(32)
+  throws(() => network.lookupOne(topic), Error('Bind before doing a lookup'))
+})
+
+test('lookup before bind will throw', async ({ throws }) => {
+  const network = guts()
+  const topic = randomBytes(32)
+  throws(() => network.lookup(topic), Error('Bind before doing a lookup'))
 })
 
 test('connect two peers with address details', async ({ is, pass }) => {

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ const net = require('net')
 const dgram = require('dgram')
 const UTP = require('utp-native')
 const once = require('events.once')
-const { test, only } = require('tap')
+const { test } = require('tap')
 const guts = require('..')
 
 const promisifyApi = (o) => {


### PR DESCRIPTION
* covers retry cases
* covers error cases
* holepunch command test for referrer peers
* coverage up from +16% (stmts), +30% (branch), +12% (funcs – now at 100%), +10% lines
* more reliable testing pattern (using when/until in socket handlers)

still todo: 

* holepunch coverage with referrer *before* tcp client connects
* utp retries and errors in same referrer scenario
* preferredPort in bind
* triggering retry scenarios via bind (in addition to referrer triggered binding)
* lookup method