### PR TITLE
full cov and bug fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const utp = require('utp-native')
 const net = require('net')
 const Nanoresource = require('nanoresource')
@@ -46,7 +47,6 @@ class NetworkResource extends Nanoresource {
     tcp.on('close', onclose)
 
     if (!peer.referrer) return
-
     closes++
     this.open(onopen)
 
@@ -74,7 +74,6 @@ class NetworkResource extends Nanoresource {
 
     function onconnect () {
       const socket = this
-
       if (self.closed || connected) return socket.destroy()
 
       connected = true
@@ -101,7 +100,7 @@ class NetworkResource extends Nanoresource {
 
   lookup (key, cb) {
     if (!this.discovery) throw new Error('Bind before doing a lookup')
-    this.discovery.lookup(key, cb)
+    return this.discovery.lookup(key)
   }
 
   bind (preferredPort, cb) {
@@ -146,7 +145,6 @@ class NetworkResource extends Nanoresource {
 
     function ondiscoveryclose () {
       let missing = 2
-
       for (const socket of self.sockets) socket.destroy()
       self.sockets.clear()
 
@@ -172,7 +170,7 @@ function listenBoth (tcp, utp, port, cb) {
 
     listen(utp, tcp.address().port, function (err) {
       if (err) {
-        tcp.once('close', cb)
+        tcp.once('close', () => cb(err))
         tcp.close()
         return
       }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "The networking guts of Hyperswarm",
   "main": "index.js",
   "scripts": {
-    "test": "tap test/*.js && standard --fix",
-    "cov": "tap --100 test/*.js"
+    "test": "tap -T test/*.js && standard --fix",
+    "cov": "tap -T --100 test/*.js"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@hyperswarm/dht": "0.0.1",
     "events.once": "^2.0.2",
+    "get-port": "^5.0.0",
     "standard": "^12.0.1",
     "tap": "^12.6.6"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -585,7 +585,6 @@ test('temporary tcp connection outage prior holepunch from bind due to referrer'
   // results in a utp connection instead of tcp
   const { bootstrap, closeDht } = await dhtBootstrap()
   const network = promisifyApi(guts({ bootstrap }))
-  network.name = 'network'
   await network.bind()
   const { port } = network.address()
   const client = promisifyApi(guts({
@@ -602,7 +601,6 @@ test('temporary tcp connection outage prior holepunch from bind due to referrer'
     },
     bootstrap
   }))
-  client.name = 'client'
   const referrer = dgram.createSocket('udp4')
   await promisify(referrer.bind.bind(referrer))()
   const connecting = client.connect({


### PR DESCRIPTION
variety of network failure scenarios tested

two bugs found and fixed: 

* lookup wasn't returning an eventemitter - is now
* utp errors were being swallowed, now they propagate 

coverage at 100%: 

![image](https://user-images.githubusercontent.com/1190716/56989617-2bc1da80-6b93-11e9-9a60-a48b23615d82.png)
